### PR TITLE
[데이먼] 컬럼 엔티티 및 기본 동작 추가

### DIFF
--- a/BE/src/main/java/com/team26/todolist/controller/ColumnController.java
+++ b/BE/src/main/java/com/team26/todolist/controller/ColumnController.java
@@ -1,0 +1,57 @@
+package com.team26.todolist.controller;
+
+import com.team26.todolist.dto.request.ColumnMoveRequest;
+import com.team26.todolist.dto.request.ColumnRegistrationRequest;
+import com.team26.todolist.dto.request.ColumnUpdateRequest;
+import com.team26.todolist.dto.response.ColumnResponse;
+import com.team26.todolist.service.ColumnService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/columns")
+public class ColumnController {
+
+    private final ColumnService columnService;
+
+    public ColumnController(ColumnService columnService) {
+        this.columnService = columnService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ColumnResponse> createColumn(@RequestBody ColumnRegistrationRequest columnRegistrationRequest) {
+        ColumnResponse savedColumn = columnService.addColumn(columnRegistrationRequest);
+
+
+        return ResponseEntity.ok()
+                .body(savedColumn);
+    }
+
+    @PutMapping
+    public ResponseEntity<ColumnResponse> updateColumn(@RequestBody ColumnUpdateRequest columnUpdateRequest) {
+        ColumnResponse updatedCard = columnService.modifyColumn(columnUpdateRequest);
+
+        return ResponseEntity.ok()
+                .body(updatedCard);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ColumnResponse> changeColumnOrder(@RequestBody ColumnMoveRequest columnMoveRequest) {
+        ColumnResponse movedColumn = columnService.changeColumnOrder(columnMoveRequest);
+
+        return ResponseEntity.ok()
+                .body(movedColumn);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteColumn(@RequestBody Long id) {
+        columnService.deleteCard(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/domain/Column.java
+++ b/BE/src/main/java/com/team26/todolist/domain/Column.java
@@ -1,0 +1,78 @@
+package com.team26.todolist.domain;
+
+import java.time.LocalDateTime;
+
+public class Column {
+
+    private Long id;
+    private String title;
+    private Double order;
+    private LocalDateTime createdAt;
+    private boolean isDeleted;
+
+    public Column(ColumnBuilder columnBuilder) {
+        this.id = columnBuilder.id;
+        this.title = columnBuilder.title;
+        this.order = columnBuilder.order;
+        this.createdAt = columnBuilder.createdAt;
+        this.isDeleted = columnBuilder.isDeleted;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Double getOrder() {
+        return order;
+    }
+
+    public static ColumnBuilder builder() {
+        return new ColumnBuilder();
+    }
+
+    public static class ColumnBuilder {
+
+        private Long id;
+        private String title;
+        private Double order;
+        private LocalDateTime createdAt;
+        private boolean isDeleted;
+
+        public ColumnBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public ColumnBuilder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public ColumnBuilder order(Double order) {
+            this.order = order;
+            return this;
+        }
+
+        public ColumnBuilder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public ColumnBuilder isDeleted(boolean deleted) {
+            isDeleted = deleted;
+            return this;
+        }
+
+        public Column build() {
+            return new Column(this);
+        }
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/dto/request/ColumnMoveRequest.java
+++ b/BE/src/main/java/com/team26/todolist/dto/request/ColumnMoveRequest.java
@@ -1,0 +1,35 @@
+package com.team26.todolist.dto.request;
+
+import com.team26.todolist.domain.Column;
+
+public class ColumnMoveRequest {
+
+    private Long id;
+    private Double orderOfLeftColumn;
+    private Double orderOfRightColumn;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Double getOrderOfLeftColumn() {
+        return orderOfLeftColumn;
+    }
+
+    public Double getOrderOfRightColumn() {
+        return orderOfRightColumn;
+    }
+
+    public Column toEntity() {
+        return Column.builder().id(id).build();
+    }
+
+    @Override
+    public String toString() {
+        return "ColumnMoveRequest{" +
+                "id=" + id +
+                ", orderOfLeftColumn=" + orderOfLeftColumn +
+                ", orderOfRightColumn=" + orderOfRightColumn +
+                '}';
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/dto/request/ColumnRegistrationRequest.java
+++ b/BE/src/main/java/com/team26/todolist/dto/request/ColumnRegistrationRequest.java
@@ -1,0 +1,16 @@
+package com.team26.todolist.dto.request;
+
+import com.team26.todolist.domain.Column;
+
+public class ColumnRegistrationRequest {
+
+    private String title;
+
+    public Column toEntity() {
+        return Column.builder().title(title).build();
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/dto/request/ColumnUpdateRequest.java
+++ b/BE/src/main/java/com/team26/todolist/dto/request/ColumnUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.team26.todolist.dto.request;
+
+import com.team26.todolist.domain.Column;
+
+public class ColumnUpdateRequest {
+
+    private Long id;
+    private String title;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Column toEntity() {
+        return Column.builder().id(id).title(title).build();
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/dto/response/ColumnResponse.java
+++ b/BE/src/main/java/com/team26/todolist/dto/response/ColumnResponse.java
@@ -1,0 +1,34 @@
+package com.team26.todolist.dto.response;
+
+import com.team26.todolist.domain.Column;
+
+public class ColumnResponse {
+    private Long id;
+    private String title;
+    private Double order;
+
+    public ColumnResponse() {
+    }
+
+    public ColumnResponse(Long id, String title, Double order) {
+        this.id = id;
+        this.title = title;
+        this.order = order;
+    }
+
+    public static ColumnResponse of(Column column) {
+        return new ColumnResponse(column.getId(), column.getTitle(), column.getOrder());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Double getOrder() {
+        return order;
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/repository/ColumnRepository.java
+++ b/BE/src/main/java/com/team26/todolist/repository/ColumnRepository.java
@@ -1,0 +1,14 @@
+package com.team26.todolist.repository;
+
+import com.team26.todolist.domain.Column;
+
+public interface ColumnRepository {
+
+    Column findById(Long id);
+    Column updateOrder(Column column, Double order);
+    Column updateTitle(Column column);
+    boolean delete(Long id);
+    Column save(Column column, Double order);
+    Double getLastOrder();
+
+}

--- a/BE/src/main/java/com/team26/todolist/repository/ColumnRepositoryImpl.java
+++ b/BE/src/main/java/com/team26/todolist/repository/ColumnRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.team26.todolist.repository;
+
+import com.team26.todolist.domain.Column;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ColumnRepositoryImpl implements ColumnRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final RowMapper<Column> columnRowMapper = columnRowMapper();
+    private final KeyHolder keyHolder = new GeneratedKeyHolder();
+
+    public ColumnRepositoryImpl(
+            NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+    }
+
+    @Override
+    public Column findById(Long id) {
+        String sql = "SELECT id, title, order_index, created_at FROM column_tbl WHERE id = :id";
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", id);
+        return namedParameterJdbcTemplate.queryForObject(sql, params, columnRowMapper);
+    }
+
+    @Override
+    public Column updateOrder(Column column, Double newOrder) {
+        String sql = "UPDATE column_tbl SET order_index = :order WHERE id = :id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("order", newOrder);
+        params.put("id", column.getId());
+
+        namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource().addValues(params));
+
+        return findById(column.getId());
+    }
+
+    @Override
+    public Column updateTitle(Column column) {
+        String sql = "UPDATE column_tbl SET title = :title WHERE id = :id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("title", column.getTitle());
+        params.put("id", column.getId());
+
+        namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource().addValues(params));
+
+        return findById((column.getId()));
+    }
+
+
+    @Override
+    public boolean delete(Long id) {
+        String sql = "UPDATE column_tbl SET deleted = :isDeleted WHERE id = :id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("isDeleted", true);
+        params.put("id", id);
+
+        int countAffected = namedParameterJdbcTemplate.update(sql, params);
+        return countAffected == 1;
+    }
+
+    @Override
+    public Column save(Column column, Double order) {
+        String sql = "INSERT INTO column_tbl (title, order_index, created_at, deleted) "
+                + " VALUES (:title, :order, :createdAt, :isDeleted)";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("title", column.getTitle());
+        params.put("order", order);
+        params.put("createdAt", LocalDateTime.now());
+        params.put("isDeleted", false);
+
+        namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource().addValues(params),
+                keyHolder);
+
+
+        return findById((long) keyHolder.getKey());
+    }
+
+    @Override
+    public Double getLastOrder() {
+        String sql = "SELECT MAX(order_index) AS last_order FROM column_tbl";
+        Double lastOrder = namedParameterJdbcTemplate.queryForObject(
+                sql, new HashMap<>(), Double.class);
+        return lastOrder;
+    }
+
+    private RowMapper<Column> columnRowMapper() {
+        return ((rs, rowNum) ->
+                Column.builder()
+                        .id(rs.getLong("id"))
+                        .title(rs.getString("title"))
+                        .order(rs.getDouble("order_index"))
+                        .createdAt(rs.getObject("created_at", LocalDateTime.class))
+                        .build()
+                );
+    }
+}

--- a/BE/src/main/java/com/team26/todolist/repository/HistoryRepositoryImpl.java
+++ b/BE/src/main/java/com/team26/todolist/repository/HistoryRepositoryImpl.java
@@ -48,16 +48,12 @@ public class HistoryRepositoryImpl implements HistoryRepository {
         parameters.put("user_id", history.getUserId());
         parameters.put("card_title", history.getCardTitle());
         parameters.put("card_title_before", history.getCardTitleBefore());
-        if (history.getCardStatus() != null) {
-            parameters.put("card_status", history.getCardStatus().name());
-        } else {
-            parameters.put("card_status", CardStatus.UNCLASSIFIED.name());
-        }
-        if (history.getCardStatusBefore() != null) {
-            parameters.put("card_status_before", history.getCardStatusBefore().name());
-        } else {
-            parameters.put("card_status_before", CardStatus.UNCLASSIFIED.name());
-        }
+        parameters.put("card_status",
+                history.getCardStatus() == null ? CardStatus.UNCLASSIFIED.name()
+                        : history.getCardStatus().name());
+        parameters.put("card_status_before",
+                history.getCardStatusBefore() == null ? CardStatus.UNCLASSIFIED.name()
+                        : history.getCardStatusBefore().name());
         parameters.put("created_at", history.getCreatedAt());
 
         Long key = (Long) jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(parameters));

--- a/BE/src/main/java/com/team26/todolist/service/ColumnService.java
+++ b/BE/src/main/java/com/team26/todolist/service/ColumnService.java
@@ -1,0 +1,16 @@
+package com.team26.todolist.service;
+
+import com.team26.todolist.domain.Column;
+import com.team26.todolist.dto.request.ColumnMoveRequest;
+import com.team26.todolist.dto.request.ColumnRegistrationRequest;
+import com.team26.todolist.dto.request.ColumnUpdateRequest;
+import com.team26.todolist.dto.response.ColumnResponse;
+
+public interface ColumnService {
+
+    ColumnResponse addColumn(ColumnRegistrationRequest columnRegistrationRequest);
+    ColumnResponse changeColumnOrder(ColumnMoveRequest columnMoveRequest);
+    ColumnResponse modifyColumn(ColumnUpdateRequest columnUpdateRequest);
+    boolean deleteCard(Long id);
+
+}

--- a/BE/src/main/java/com/team26/todolist/service/ColumnServiceImpl.java
+++ b/BE/src/main/java/com/team26/todolist/service/ColumnServiceImpl.java
@@ -1,0 +1,64 @@
+package com.team26.todolist.service;
+
+import com.team26.todolist.domain.Column;
+import com.team26.todolist.dto.request.CardUpdateRequest;
+import com.team26.todolist.dto.request.ColumnMoveRequest;
+import com.team26.todolist.dto.request.ColumnRegistrationRequest;
+import com.team26.todolist.dto.request.ColumnUpdateRequest;
+import com.team26.todolist.dto.response.ColumnResponse;
+import com.team26.todolist.repository.ColumnRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ColumnServiceImpl implements ColumnService{
+
+    private final double DIFFERENCE = 1000.0;
+
+    private final ColumnRepository columnRepository;
+
+    public ColumnServiceImpl(ColumnRepository columnRepository) {
+        this.columnRepository = columnRepository;
+    }
+
+    public ColumnResponse addColumn(ColumnRegistrationRequest columnRegistrationRequest) {
+        Double lastOrder = columnRepository.getLastOrder();
+        Double order = lastOrder + DIFFERENCE;
+        Column saveColumn = columnRepository.save(columnRegistrationRequest.toEntity(), order);
+        return ColumnResponse.of(saveColumn);
+    }
+
+    public ColumnResponse changeColumnOrder(ColumnMoveRequest columnMoveRequest) {
+        Double newOrder = getNewOrder(columnMoveRequest);
+        Column updatedColumn = columnRepository.updateOrder(columnMoveRequest.toEntity(), newOrder);
+        return ColumnResponse.of(updatedColumn);
+    }
+
+    private double getNewOrder(ColumnMoveRequest columnMoveRequest) {
+        Double orderLeft = columnMoveRequest.getOrderOfLeftColumn();
+        Double orderRight = columnMoveRequest.getOrderOfRightColumn();
+
+        if (orderLeft == null) {
+            return orderRight - DIFFERENCE;
+        }
+
+        if(orderRight == null) {
+            return orderLeft + DIFFERENCE;
+        }
+
+        return (orderLeft + orderRight) / 2;
+    }
+
+    public ColumnResponse modifyColumn(ColumnUpdateRequest columnUpdateRequest) {
+        Column columnBefore = columnRepository.findById(columnUpdateRequest.getId());
+        Double order = columnBefore.getOrder();
+
+        Column updatedColumn = columnRepository.updateTitle(columnUpdateRequest.toEntity());
+
+        return ColumnResponse.of(updatedColumn);
+    }
+
+    public boolean deleteCard(Long id) {
+        return columnRepository.delete(id);
+    }
+
+}

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     init:
       mode: always
       schema-locations: classpath:sql/schema.sql
-#      data-locations: classpath:sql/data.sql
+      data-locations: classpath:sql/data.sql
   h2:
     console:
       enabled: true

--- a/BE/src/main/resources/sql/data.sql
+++ b/BE/src/main/resources/sql/data.sql
@@ -25,3 +25,12 @@ values ('DELETE', 'test3', '', '카드 제목 이전 3', 'UNCLASSIFIED', 'ONGOIN
 insert into history(card_action, user_id, card_title, card_title_before, card_status,
                     card_status_before, created_at)
 values ('ADD', 'test4', '카드 제목 4', '', 'ONGOING', 'UNCLASSIFIED', CURRENT_TIMESTAMP);
+
+INSERT INTO column_tbl(title, order_index, deleted, created_at)
+VALUES ('할 일', 0.0, false, CURRENT_TIMESTAMP);
+
+INSERT INTO column_tbl(title, order_index, deleted, created_at)
+VALUES ('하고 있는 일', 1000.0, false, CURRENT_TIMESTAMP);
+
+INSERT INTO column_tbl(title, order_index, deleted, created_at)
+VALUES ('완료한 일', 2000.0, false, CURRENT_TIMESTAMP);

--- a/BE/src/main/resources/sql/schema.sql
+++ b/BE/src/main/resources/sql/schema.sql
@@ -1,13 +1,13 @@
 DROP TABLE IF EXISTS card;
 CREATE TABLE card
 (
-    id                BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    title             VARCHAR(50)                       NOT NULL,
-    contents          VARCHAR(500)                      NOT NULL,
-    user_id           VARCHAR(20)                       ,
-    card_status       VARCHAR(10)                       NOT NULL,
-    deleted           BOOLEAN                           NOT NULL,
-    created_at        TIMESTAMP                         NOT NULL
+    id          BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    title       VARCHAR(50)                       NOT NULL,
+    contents    VARCHAR(500)                      NOT NULL,
+    user_id     VARCHAR(20),
+    card_status VARCHAR(10)                       NOT NULL,
+    deleted     BOOLEAN                           NOT NULL,
+    created_at  TIMESTAMP                         NOT NULL
 );
 
 DROP TABLE IF EXISTS history;
@@ -15,10 +15,20 @@ CREATE TABLE history
 (
     id                 BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
     card_action        VARCHAR(20)                       NOT NULL,
-    user_id            VARCHAR(20)                       ,
-    card_title         VARCHAR(50)                       ,
-    card_title_before  VARCHAR(50)                       ,
-    card_status        VARCHAR(20)                       ,
-    card_status_before VARCHAR(20)                       ,
+    user_id            VARCHAR(20),
+    card_title         VARCHAR(50),
+    card_title_before  VARCHAR(50),
+    card_status        VARCHAR(20),
+    card_status_before VARCHAR(20),
     created_at         TIMESTAMP                         NOT NULL
+);
+
+DROP TABLE IF EXISTS column_tbl;
+CREATE TABLE column_tbl
+(
+    id          BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    title       VARCHAR(50)                       NOT NULL,
+    order_index DOUBLE                            NOT NULL,
+    deleted     BOOLEAN                           NOT NULL,
+    created_at  TIMESTAMP                         NOT NULL
 );


### PR DESCRIPTION
# 컬럼 관련 API

## 컬럼 추가

* METHOD : GET
* URL : http://localhost:8080/columns
* request body

```json
{
    "title": "해야만 할 것 같은 일"
}
```

* response body

```json
{
    "id": 4,
    "title": "해야만 할 것 같은 일",
    "order": 3000.0
}
```

## 컬럼 제목 수정

* METHOD : POST
* URL : http://localhost:8080/columns
* request body

```json
{
    "id": 2,
    "title": "하고 있을까"
}
```

* response body

```json
{
    "id": 2,
    "title": "하고 있을까",
    "order": 1000.0
}
```

## 컬럼 이동

* METHOD : PATCH
* URL : http://localhost:8080/columns
* request body
  * 이동할 곳 왼쪽 컬럼 , 오른쪽 컬럼의 order data를 보내는게 나은지 id만 보내는게 나은지 고민 중
  * FE와 어떤 방식이 나은지 협의 필요 
```json
{
    "id": 3,
    "orderOfLeftColumn": 1000.0,
    "orderOfRightColumn": 2000.0
}
```

* response body

```json
{
    "id": 3,
    "title": "완료한 일",
    "order": 1500.0
}
```

## 컬럼 삭제

* METHOD : DELETE
* URL : http://localhost:8080/columns
* request body
  * SOFT DELETE 사용
  * 삭제하고자 하는 컬럼 id만 바디에 담아 요청

```json
1
```